### PR TITLE
make consent cookie expire in 1 month

### DIFF
--- a/src/lib/Interface.js
+++ b/src/lib/Interface.js
@@ -372,7 +372,7 @@ export default class Interface {
   }
   
   setCookie(cookie, callback) {
-    const expires_in = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toUTCString();
+    const expires_in = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toUTCString();
 
     document.cookie = `cconsent=${JSON.stringify(cookie)}; expires=${expires_in}; path=/;`;
     if (callback) callback();


### PR DESCRIPTION
Make the consent cookie expire in 1 month, so every month we ask the user for the consent.